### PR TITLE
feat: update to cabinetry 0.2.1

### DIFF
--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -1,1 +1,1 @@
-cabinetry[contrib]==0.2.0
+cabinetry[contrib]==0.2.1

--- a/config_example.yml
+++ b/config_example.yml
@@ -32,7 +32,6 @@ Systematics:
       Normalization: 0.05
     Down:
       Normalization: -0.05
-    Samples: ["Signal", "Background"]
     Type: "Normalization"
 
   - Name: "Modeling"


### PR DESCRIPTION
This updates to the latest `cabinetry` version. The `Samples` argument for systematic now defaults to all samples, the config has been updated accordingly.