### PR TITLE
docs: add license and link to PyHEP talk

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,29 @@
+BSD 3-Clause License
+
+Copyright (c) 2021, Alexander Held
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -5,3 +5,5 @@
 This repository collects tutorial material for [cabinetry](https://github.com/alexander-held/cabinetry/):
 - `example.ipynb`: walkthrough for basic `cabinetry` usage, [run on Binder](https://mybinder.org/v2/gh/cabinetry/cabinetry-tutorials/master?filepath=example.ipynb)!
 - `HEPData_workspace.ipynb`: using `cabinetry` with a workspace from HEPData, [run on Binder](https://mybinder.org/v2/gh/cabinetry/cabinetry-tutorials/master?filepath=HEPData_workspace.ipynb)!
+
+See also the [PyHEP 2021 talk: *Binned template fits with cabinetry*](https://indico.cern.ch/event/1019958/contributions/4421868/) and the associated notebook in the [PyHEP-2021-cabinetry](https://github.com/alexander-held/PyHEP-2021-cabinetry/) repository.


### PR DESCRIPTION
Adding license to repository and a link to the [PyHEP 2021 talk: *Binned template fits with cabinetry*](https://indico.cern.ch/event/1019958/contributions/4421868/) and associated [PyHEP-2021-cabinetry](https://github.com/alexander-held/PyHEP-2021-cabinetry/) repository.