### PR TITLE
docs: Python version details

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,4 +11,4 @@ See also the [PyHEP 2021 talk: *Binned template fits with cabinetry*](https://in
 
 The tutorials in this repository are generally kept up-to-date with the latest available `cabinetry` version.
 They are currently compatible with `cabinetry` [`v0.3.0`](https://github.com/alexander-held/cabinetry/releases/tag/v0.3.0).
-This `cabinetry` version requires Python 3.7 or 3.8, since `cabinetry` dropped support for Python 3.6 with version [`v0.2.0`](https://github.com/alexander-held/cabinetry/releases/tag/v0.2.0).
+This `cabinetry` version requires Python 3.7 or newer, since `cabinetry` dropped support for Python 3.6 with version [`v0.2.0`](https://github.com/alexander-held/cabinetry/releases/tag/v0.2.0).


### PR DESCRIPTION
`cabinetry` 0.3.0 supports Python 3.9, so update the readme to reflect that the possible versions to be used are no longer as restricted as before.