### PR TITLE
docs: update links after cabinetry's migration to Scikit-HEP

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,12 @@
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/cabinetry/cabinetry-tutorials/master)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.5121551.svg)](https://doi.org/10.5281/zenodo.5121551)
 
-This repository collects tutorial material for [cabinetry](https://github.com/alexander-held/cabinetry/):
+This repository collects tutorial material for [cabinetry](https://github.com/scikit-hep/cabinetry/):
 - `example.ipynb`: walkthrough for basic `cabinetry` usage, [run on Binder](https://mybinder.org/v2/gh/cabinetry/cabinetry-tutorials/master?filepath=example.ipynb)!
 - `HEPData_workspace.ipynb`: using `cabinetry` with a workspace from HEPData, [run on Binder](https://mybinder.org/v2/gh/cabinetry/cabinetry-tutorials/master?filepath=HEPData_workspace.ipynb)!
 
 See also the [PyHEP 2021 talk: *Binned template fits with cabinetry*](https://indico.cern.ch/event/1019958/contributions/4421868/) and the associated notebook in the [PyHEP-2021-cabinetry](https://github.com/alexander-held/PyHEP-2021-cabinetry/) repository.
 
 The tutorials in this repository are generally kept up-to-date with the latest available `cabinetry` version.
-They are currently compatible with `cabinetry` [`v0.3.0`](https://github.com/alexander-held/cabinetry/releases/tag/v0.3.0).
-This `cabinetry` version requires Python 3.7 or newer, since `cabinetry` dropped support for Python 3.6 with version [`v0.2.0`](https://github.com/alexander-held/cabinetry/releases/tag/v0.2.0).
+They are currently compatible with `cabinetry` [`v0.3.0`](https://github.com/scikit-hep/cabinetry/releases/tag/v0.3.0).
+This `cabinetry` version requires Python 3.7 or newer, since `cabinetry` dropped support for Python 3.6 with version [`v0.2.0`](https://github.com/scikit-hep/cabinetry/releases/tag/v0.2.0).


### PR DESCRIPTION
`cabinetry` has moved to https://github.com/scikit-hep/cabinetry/, this updates the links accordingly.